### PR TITLE
Handle long menus

### DIFF
--- a/src/static/css/page-header.css
+++ b/src/static/css/page-header.css
@@ -50,6 +50,12 @@
 	position: relative;
 }
 
+#topNavigation .dropdown-menu {
+	max-height: 640px;
+	max-height: calc(100vh - 62px);
+	overflow-y: auto;
+}
+
 @media (min-width: 768px) {
 	.page-header {
 		padding-top: 60px;

--- a/src/static/css/toc.css
+++ b/src/static/css/toc.css
@@ -9,6 +9,9 @@
 .toc-nav {
 	margin-top: 5px;
 	padding-bottom: 10px;
+	max-height: 95%;
+	max-height: calc(100% - 2em);
+	overflow-y: auto;
 }
 
 /* All levels of nav */


### PR DESCRIPTION
This adds max-height and overflow to the top menubar's dropdowns and the toc's menubar in order to not overflow the screen in case of long lists.

Taken from docstrap.