### PR TITLE
Add 'inherited' attribute to inherited members

### DIFF
--- a/src/utils/docletHelper.js
+++ b/src/utils/docletHelper.js
@@ -29,6 +29,9 @@ var getLinkText = exports.getLinkText = function(doclet){
 exports.getAttribs = function (doclet) {
 	if (supportsParams(doclet) || doclet.kind === 'member' || doclet.kind === 'constant') {
 		var attribs = helper.getAttribs(doclet);
+		if (doclet.inherited && attribs.indexOf('inherited') === -1) {
+			attribs.push('inherited');
+		}
 		return attribs.length ? '<span class="signature-attribs">' + helper.htmlsafe('<' + attribs.join(', ') + '> ') + '</span>' : '';
 	}
 	return '';


### PR DESCRIPTION
jsdoc helper does not add it, so I made it compatible with a future evolution (to avoid duplicates).

It could be an option if you want.