### PR TITLE
Fix constants not displayed

### DIFF
--- a/src/utils/docletHelper.js
+++ b/src/utils/docletHelper.js
@@ -64,8 +64,7 @@ exports.getSignature = function (doclet) {
 	} else if (doclet.kind === 'member' || doclet.kind === 'constant') {
 		var types = helper.getSignatureTypes(doclet);
 		signature += '<span class="signature-type">' + (types.length ? ' :' + types.join('|') : '') + '</span>';
-		//todo: check if this is required
-		//doclet.kind = 'member';
+		doclet.kind = 'member';
 	}
 	return signature;
 };


### PR DESCRIPTION
To answer the TODO : yes this line is required, I could not explain why but the default jsDoc template has it and it resolved my constants not being displayed :-)